### PR TITLE
fix: expose explainGraphiQLPlugin types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,3 +7,9 @@ export interface MercuriusExplainOptions {
 declare const mercuriusExplain: FastifyPluginAsync<MercuriusExplainOptions>
 
 export default mercuriusExplain
+
+export declare function explainGraphiQLPlugin(options?: { version?: string }): {
+  name: string,
+  umdUrl: string,
+  fetcherWrapper: string,
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,8 +8,16 @@ declare const mercuriusExplain: FastifyPluginAsync<MercuriusExplainOptions>
 
 export default mercuriusExplain
 
-export declare function explainGraphiQLPlugin(options?: { version?: string }): {
-  name: string,
-  umdUrl: string,
-  fetcherWrapper: string,
-};
+export type ExplainGraphiQLPluginOptions = {
+  version?: string
+}
+
+export type ExplainGraphiQLPluginReturnType = {
+  name: string
+  umdUrl: string
+  fetcherWrapper: string
+}
+
+export declare function explainGraphiQLPlugin(
+  options?: ExplainGraphiQLPluginOptions
+): ExplainGraphiQLPluginReturnType

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,6 +1,19 @@
-import { expectAssignable } from 'tsd'
-import { MercuriusExplainOptions } from '../../index'
+import { expectAssignable, expectType, expectError } from 'tsd'
+import { MercuriusExplainOptions, explainGraphiQLPlugin } from '../../index'
 const mercuriusExplainOptions = {
   enabled: true
 }
 expectAssignable<MercuriusExplainOptions>(mercuriusExplainOptions)
+
+// explainGraphiQLPlugin
+type ExplainGraphiQLPluginReturnType = {
+  name: string,
+  umdUrl: string,
+  fetcherWrapper: string,
+};
+
+expectType<ExplainGraphiQLPluginReturnType>(explainGraphiQLPlugin())
+expectType<ExplainGraphiQLPluginReturnType>(explainGraphiQLPlugin({}))
+expectType<ExplainGraphiQLPluginReturnType>(explainGraphiQLPlugin({version: 'v1'}))
+// Version should only accept strings
+expectError(explainGraphiQLPlugin({version: 2}))

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,9 +1,15 @@
+import type { FastifyPluginAsync } from 'fastify'
 import { expectAssignable, expectType, expectError } from 'tsd'
-import { MercuriusExplainOptions, explainGraphiQLPlugin } from '../../index'
+import explain, { MercuriusExplainOptions, explainGraphiQLPlugin } from '../../index'
+
+// MercuriusExplainOptions
 const mercuriusExplainOptions = {
   enabled: true
 }
 expectAssignable<MercuriusExplainOptions>(mercuriusExplainOptions)
+
+// default export
+expectType<FastifyPluginAsync<MercuriusExplainOptions>>(explain)
 
 // explainGraphiQLPlugin
 type ExplainGraphiQLPluginReturnType = {

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,6 +1,10 @@
 import type { FastifyPluginAsync } from 'fastify'
 import { expectAssignable, expectType, expectError } from 'tsd'
-import explain, { MercuriusExplainOptions, explainGraphiQLPlugin } from '../../index'
+import explain, {
+  MercuriusExplainOptions,
+  explainGraphiQLPlugin,
+  ExplainGraphiQLPluginReturnType
+} from '../../index'
 
 // MercuriusExplainOptions
 const mercuriusExplainOptions = {
@@ -12,14 +16,10 @@ expectAssignable<MercuriusExplainOptions>(mercuriusExplainOptions)
 expectType<FastifyPluginAsync<MercuriusExplainOptions>>(explain)
 
 // explainGraphiQLPlugin
-type ExplainGraphiQLPluginReturnType = {
-  name: string,
-  umdUrl: string,
-  fetcherWrapper: string,
-};
-
 expectType<ExplainGraphiQLPluginReturnType>(explainGraphiQLPlugin())
 expectType<ExplainGraphiQLPluginReturnType>(explainGraphiQLPlugin({}))
-expectType<ExplainGraphiQLPluginReturnType>(explainGraphiQLPlugin({version: 'v1'}))
+expectType<ExplainGraphiQLPluginReturnType>(
+  explainGraphiQLPlugin({ version: 'v1' })
+)
 // Version should only accept strings
-expectError(explainGraphiQLPlugin({version: 2}))
+expectError(explainGraphiQLPlugin({ version: 2 }))


### PR DESCRIPTION
Expose `explainGraphiQLPlugin` types and add relevant `tsd` type tests.

Closes: #83 #84