### PR TITLE
chore: update mercurius peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "fastify": "4.x",
-    "mercurius": "11.x"
+    "mercurius": ">=11.x"
   },
   "dependencies": {
     "fastify-plugin": "^4.2.1",


### PR DESCRIPTION
With the previous version, the exactly version of mercurius was needed. I don't know if there's something added in `mercurius@11.0.0` that is needed for this lib to work, but we may lower the required version, or even put `"mercurius": "*"`