### PR TITLE
chore: migrate to OIDC publishing for npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   release:
+    environment: production
     permissions:
       contents: write
       issues: write
@@ -27,11 +28,5 @@ jobs:
         with:
           semver: ${{ github.event.inputs.semver }}
           commit-message: 'chore: release {version}'
-          npm-token: >-
-            ${{ secrets[format('NPM_TOKEN_{0}', github.actor)] ||
-            secrets.NPM_TOKEN }}
-          optic-token: >-
-            ${{ secrets[format('OPTIC_TOKEN_{0}', github.actor)] ||
-            secrets.OPTIC_TOKEN }}
+          publish-mode: oidc
           build-command: npm ci
-          provenance: true


### PR DESCRIPTION
- Add OIDC trusted publishing support
- Remove npm token and optic-token dependencies
- Add production environment and required permissions
- Update to publish-mode: oidc

This migration eliminates the need for npm tokens and provides enhanced security through GitHub's identity provider.